### PR TITLE
msdkdec: Update frame info from video parameters

### DIFF
--- a/sys/msdk/gstmsdkdec.c
+++ b/sys/msdk/gstmsdkdec.c
@@ -205,6 +205,8 @@ get_surface (GstMsdkDec * thiz, GstBuffer * buffer)
       goto failed_unref_buffer2;
   }
 
+  gst_msdk_update_mfx_frame_info_from_mfx_video_param (&i->surface->Info,
+      &thiz->param);
   thiz->decoded_msdk_surfaces = g_list_append (thiz->decoded_msdk_surfaces, i);
   return i;
 

--- a/sys/msdk/msdk.c
+++ b/sys/msdk/msdk.c
@@ -377,3 +377,12 @@ gst_msdk_get_video_format_from_mfx_fourcc (mfxU32 fourcc)
 
   return GST_VIDEO_FORMAT_UNKNOWN;
 }
+
+void
+gst_msdk_update_mfx_frame_info_from_mfx_video_param (mfxFrameInfo * mfx_info,
+    mfxVideoParam * param)
+{
+  mfx_info->BitDepthLuma = param->mfx.FrameInfo.BitDepthLuma;
+  mfx_info->BitDepthChroma = param->mfx.FrameInfo.BitDepthChroma;
+  mfx_info->Shift = param->mfx.FrameInfo.Shift;
+}

--- a/sys/msdk/msdk.h
+++ b/sys/msdk/msdk.h
@@ -74,6 +74,10 @@ gst_msdk_get_surface_from_buffer (GstBuffer * buf);
 GstVideoFormat
 gst_msdk_get_video_format_from_mfx_fourcc (mfxU32 fourcc);
 
+void
+gst_msdk_update_mfx_frame_info_from_mfx_video_param (mfxFrameInfo * mfx_info,
+    mfxVideoParam * param);
+
 G_END_DECLS
 
 #endif /* __MSDK_H__ */


### PR DESCRIPTION
A 10bit stream may have different depth values for Luma and Chroma, and
MSDK requires the frame info must match the corresponding video
parameters