### PR TITLE
msdkh265dec: remove the requirement on profile

### DIFF
--- a/sys/msdk/gstmsdkh265dec.c
+++ b/sys/msdk/gstmsdkh265dec.c
@@ -47,8 +47,7 @@ static GstStaticPadTemplate sink_factory = GST_STATIC_PAD_TEMPLATE ("sink",
     GST_PAD_ALWAYS,
     GST_STATIC_CAPS ("video/x-h265, "
         "width = (int) [ 1, MAX ], height = (int) [ 1, MAX ], "
-        "stream-format = (string) byte-stream , alignment = (string) au , "
-        "profile = (string) { main, main-10, main-422-10, main-422-10-intra, main-444, main-444-10, main-444-10-intra } ")
+        "stream-format = (string) byte-stream , alignment = (string) au ")
     );
 
 static GstStaticPadTemplate src_factory = GST_STATIC_PAD_TEMPLATE ("src",


### PR DESCRIPTION
Some HEVC/H265 video don't have a valid profile and MSDK can handle this
stream. Like gstreamer-vaapi, we may remove the requirement on profile
in the sink pad