### PR TITLE
msdkvpp: don't return GST_FLOW_ERROR for MFX_WRN_INCOMPATIBLE_VIDEO_P…

### DIFF
--- a/sys/msdk/gstmsdkvpp.c
+++ b/sys/msdk/gstmsdkvpp.c
@@ -727,7 +727,10 @@ gst_msdkvpp_transform (GstBaseTransform * trans, GstBuffer * inbuf,
       g_usleep (1000);
     };
 
-    if (status != MFX_ERR_NONE && status != MFX_ERR_MORE_DATA
+    if (status == MFX_WRN_INCOMPATIBLE_VIDEO_PARAM)
+      GST_WARNING_OBJECT (thiz, "VPP returned: %s",
+          msdk_status_to_string (status));
+    else if (status != MFX_ERR_NONE && status != MFX_ERR_MORE_DATA
         && status != MFX_ERR_MORE_SURFACE)
       goto vpp_error;
 


### PR DESCRIPTION
Returning MFX_WRN_INCOMPATIBLE_VIDEO_PARAM means MSDK detects some
incompatible parameters but it is resolved, and we may not regard
MFX_WRN_INCOMPATIBLE_VIDEO_PARAM as a fatal error. In this fix,
GST_FLOW_OK is returned but with a warning message so that a pipeline
may run to the end.