### PR TITLE
msdk: avoid reading data from freed memory

### DIFF
--- a/sys/msdk/gstmsdkcontext.c
+++ b/sys/msdk/gstmsdkcontext.c
@@ -468,8 +468,9 @@ check_surfaces_available (GstMsdkContext * context, GstMsdkAllocResponse * resp)
   gboolean ret = FALSE;
 
   g_mutex_lock (&priv->mutex);
-  for (l = resp->surfaces_locked; l; l = l->next) {
+  for (l = resp->surfaces_locked; l;) {
     surface = l->data;
+    l = l->next;
     if (!surface->Data.Locked) {
       resp->surfaces_locked = g_list_remove (resp->surfaces_locked, surface);
       resp->surfaces_avail = g_list_prepend (resp->surfaces_avail, surface);
@@ -503,9 +504,9 @@ gst_msdk_context_get_surface_available (GstMsdkContext * context,
 
 retry:
   g_mutex_lock (&priv->mutex);
-  for (l = msdk_resp->surfaces_avail; l; l = l->next) {
+  for (l = msdk_resp->surfaces_avail; l;) {
     surface = l->data;
-
+    l = l->next;
     if (!surface->Data.Locked) {
       msdk_resp->surfaces_avail =
           g_list_remove (msdk_resp->surfaces_avail, surface);

--- a/sys/msdk/gstmsdkdec.c
+++ b/sys/msdk/gstmsdkdec.c
@@ -769,8 +769,9 @@ release_msdk_surfaces (GstMsdkDec * thiz)
   GList *l;
   MsdkSurface *surface;
 
-  for (l = thiz->decoded_msdk_surfaces; l; l = l->next) {
+  for (l = thiz->decoded_msdk_surfaces; l;) {
     surface = l->data;
+    l = l->next;
     free_surface (thiz, surface);
   }
 }

--- a/sys/msdk/gstmsdkenc.c
+++ b/sys/msdk/gstmsdkenc.c
@@ -647,15 +647,18 @@ gst_msdkenc_dequeue_frame (GstMsdkEnc * thiz, GstVideoCodecFrame * frame)
 {
   GList *l;
 
-  for (l = thiz->pending_frames; l; l = l->next) {
+  for (l = thiz->pending_frames; l;) {
     FrameData *fdata = l->data;
+    GList *l1 = l;
+
+    l = l->next;
 
     if (fdata->frame != frame)
       continue;
 
     gst_msdkenc_free_frame_data (thiz, fdata);
 
-    thiz->pending_frames = g_list_delete_link (thiz->pending_frames, l);
+    thiz->pending_frames = g_list_delete_link (thiz->pending_frames, l1);
     return;
   }
 }


### PR DESCRIPTION
Both g_list_delete_link and g_list_remove remove an element and free it.
so l->next is invalid after g_list_delete_link or g_list_remove