### PR TITLE
msdk: Use Video memory only if linked element is also MSDK element

### DIFF
--- a/sys/msdk/gstmsdkdec.c
+++ b/sys/msdk/gstmsdkdec.c
@@ -44,21 +44,10 @@
 GST_DEBUG_CATEGORY_EXTERN (gst_msdkdec_debug);
 #define GST_CAT_DEFAULT gst_msdkdec_debug
 
-#ifndef _WIN32
-#define DMABUF_CAPS_STR \
-  GST_VIDEO_CAPS_MAKE_WITH_FEATURES (GST_CAPS_FEATURE_MEMORY_DMABUF, "{ NV12 }")
-#else
-#define DMABUF_CAPS_STR ""
-#endif
-
 static GstStaticPadTemplate src_factory = GST_STATIC_PAD_TEMPLATE ("src",
     GST_PAD_SRC,
     GST_PAD_ALWAYS,
-    GST_STATIC_CAPS ("video/x-raw, "
-        "format = (string) { NV12 }, "
-        "framerate = (fraction) [0, MAX], "
-        "width = (int) [ 1, MAX ], height = (int) [ 1, MAX ],"
-        "interlace-mode = (string) progressive;" DMABUF_CAPS_STR)
+    GST_STATIC_CAPS (GST_MSDK_CAPS_STR ("NV12", "NV12"))
     );
 
 #define PROP_HARDWARE_DEFAULT            TRUE

--- a/sys/msdk/gstmsdkenc.c
+++ b/sys/msdk/gstmsdkenc.c
@@ -76,21 +76,11 @@ static void gst_msdkenc_close_encoder (GstMsdkEnc * thiz);
 GST_DEBUG_CATEGORY_EXTERN (gst_msdkenc_debug);
 #define GST_CAT_DEFAULT gst_msdkenc_debug
 
-#ifndef _WIN32
-#define DMABUF_CAPS_STR \
-  GST_VIDEO_CAPS_MAKE_WITH_FEATURES (GST_CAPS_FEATURE_MEMORY_DMABUF, "{ NV12 }")
-#else
-#define DMABUF_CAPS_STR ""
-#endif
-
 static GstStaticPadTemplate sink_factory = GST_STATIC_PAD_TEMPLATE ("sink",
     GST_PAD_SINK,
     GST_PAD_ALWAYS,
-    GST_STATIC_CAPS ("video/x-raw, "
-        "format = (string) { NV12, I420, YV12, YUY2, UYVY, BGRA }, "
-        "framerate = (fraction) [0, MAX], "
-        "width = (int) [ 16, MAX ], height = (int) [ 16, MAX ],"
-        "interlace-mode = (string) progressive" ";" DMABUF_CAPS_STR)
+    GST_STATIC_CAPS (GST_MSDK_CAPS_STR
+        ("{ NV12, I420, YV12, YUY2, UYVY, BGRA }", "NV12"))
     );
 
 #define PROP_HARDWARE_DEFAULT            TRUE

--- a/sys/msdk/gstmsdkh265dec.c
+++ b/sys/msdk/gstmsdkh265dec.c
@@ -41,6 +41,8 @@
 GST_DEBUG_CATEGORY_EXTERN (gst_msdkh265dec_debug);
 #define GST_CAT_DEFAULT gst_msdkh265dec_debug
 
+#define COMMON_FORMAT "{ NV12, P010_10LE, YUY2, Y210, VUYA, Y410 }"
+
 /* TODO: update both sink and src dynamically */
 static GstStaticPadTemplate sink_factory = GST_STATIC_PAD_TEMPLATE ("sink",
     GST_PAD_SINK,
@@ -54,13 +56,7 @@ static GstStaticPadTemplate sink_factory = GST_STATIC_PAD_TEMPLATE ("sink",
 static GstStaticPadTemplate src_factory = GST_STATIC_PAD_TEMPLATE ("src",
     GST_PAD_SRC,
     GST_PAD_ALWAYS,
-    GST_STATIC_CAPS ("video/x-raw, "
-        "format = (string) { NV12, P010_10LE, YUY2, Y210, VUYA, Y410 }, "
-        "framerate = (fraction) [0, MAX], "
-        "width = (int) [ 1, MAX ], height = (int) [ 1, MAX ],"
-        "interlace-mode = (string) progressive;"
-        GST_VIDEO_CAPS_MAKE_WITH_FEATURES (GST_CAPS_FEATURE_MEMORY_DMABUF,
-            "{ NV12, P010_10LE, YUY2, Y210, VUYA, Y410 }") ";")
+    GST_STATIC_CAPS (GST_MSDK_CAPS_STR (COMMON_FORMAT, COMMON_FORMAT))
     );
 
 #define gst_msdkh265dec_parent_class parent_class

--- a/sys/msdk/gstmsdkh265enc.c
+++ b/sys/msdk/gstmsdkh265enc.c
@@ -49,16 +49,12 @@ enum
 
 #define PROP_LOWPOWER_DEFAULT           FALSE
 
+#define COMMON_FORMAT "{ NV12, I420, YV12, YUY2, UYVY, BGRA, P010_10LE }"
+
 static GstStaticPadTemplate sink_factory = GST_STATIC_PAD_TEMPLATE ("sink",
     GST_PAD_SINK,
     GST_PAD_ALWAYS,
-    GST_STATIC_CAPS ("video/x-raw, "
-        "format = (string) { NV12, I420, YV12, YUY2, UYVY, BGRA, P010_10LE }, "
-        "framerate = (fraction) [0, MAX], "
-        "width = (int) [ 16, MAX ], height = (int) [ 16, MAX ],"
-        "interlace-mode = (string) progressive" ";"
-        GST_VIDEO_CAPS_MAKE_WITH_FEATURES (GST_CAPS_FEATURE_MEMORY_DMABUF,
-            "{ NV12 }")));
+    GST_STATIC_CAPS (GST_MSDK_CAPS_STR (COMMON_FORMAT, "NV12")));
 
 static GstStaticPadTemplate src_factory = GST_STATIC_PAD_TEMPLATE ("src",
     GST_PAD_SRC,

--- a/sys/msdk/gstmsdkmjpegdec.c
+++ b/sys/msdk/gstmsdkmjpegdec.c
@@ -54,13 +54,7 @@ static GstStaticPadTemplate sink_factory = GST_STATIC_PAD_TEMPLATE ("sink",
 static GstStaticPadTemplate src_factory = GST_STATIC_PAD_TEMPLATE ("src",
     GST_PAD_SRC,
     GST_PAD_ALWAYS,
-    GST_STATIC_CAPS ("video/x-raw, "
-        "format = (string) { NV12, YUY2 }, "
-        "framerate = (fraction) [0, MAX], "
-        "width = (int) [ 1, MAX ], height = (int) [ 1, MAX ],"
-        "interlace-mode = (string) progressive;"
-        GST_VIDEO_CAPS_MAKE_WITH_FEATURES (GST_CAPS_FEATURE_MEMORY_DMABUF,
-            "{ NV12, YUY2 }") ";")
+    GST_STATIC_CAPS (GST_MSDK_CAPS_STR ("{ NV12, YUY2 }", "{ NV12, YUY2 }"))
     );
 
 #define gst_msdkmjpegdec_parent_class parent_class

--- a/sys/msdk/gstmsdkvp9dec.c
+++ b/sys/msdk/gstmsdkvp9dec.c
@@ -44,6 +44,8 @@
 GST_DEBUG_CATEGORY_EXTERN (gst_msdkvp9dec_debug);
 #define GST_CAT_DEFAULT gst_msdkvp9dec_debug
 
+#define COMMON_FORMAT "{ NV12, P010_10LE, VUYA, Y410 }"
+
 static GstStaticPadTemplate sink_factory = GST_STATIC_PAD_TEMPLATE ("sink",
     GST_PAD_SINK,
     GST_PAD_ALWAYS,
@@ -53,13 +55,7 @@ static GstStaticPadTemplate sink_factory = GST_STATIC_PAD_TEMPLATE ("sink",
 static GstStaticPadTemplate src_factory = GST_STATIC_PAD_TEMPLATE ("src",
     GST_PAD_SRC,
     GST_PAD_ALWAYS,
-    GST_STATIC_CAPS ("video/x-raw, "
-        "format = (string) { NV12, P010_10LE, VUYA, Y410 }, "
-        "framerate = (fraction) [0, MAX], "
-        "width = (int) [ 1, MAX ], height = (int) [ 1, MAX ],"
-        "interlace-mode = (string) progressive;"
-        GST_VIDEO_CAPS_MAKE_WITH_FEATURES (GST_CAPS_FEATURE_MEMORY_DMABUF,
-            "{ NV12, P010_10LE, VUYA, Y410 }") ";")
+    GST_STATIC_CAPS (GST_MSDK_CAPS_STR (COMMON_FORMAT, COMMON_FORMAT))
     );
 
 #define gst_msdkvp9dec_parent_class parent_class

--- a/sys/msdk/gstmsdkvp9enc.c
+++ b/sys/msdk/gstmsdkvp9enc.c
@@ -42,16 +42,12 @@
 GST_DEBUG_CATEGORY_EXTERN (gst_msdkvp9enc_debug);
 #define GST_CAT_DEFAULT gst_msdkvp9enc_debug
 
+#define COMMON_FORMAT "{ NV12, I420, YV12, YUY2, UYVY, BGRA, P010_10LE }"
+
 static GstStaticPadTemplate sink_factory = GST_STATIC_PAD_TEMPLATE ("sink",
     GST_PAD_SINK,
     GST_PAD_ALWAYS,
-    GST_STATIC_CAPS ("video/x-raw, "
-        "format = (string) { NV12, I420, YV12, YUY2, UYVY, BGRA, P010_10LE }, "
-        "framerate = (fraction) [0/1, MAX], "
-        "width = (int) [ 1, MAX ], height = (int) [ 1, MAX ],"
-        "interlace-mode = (string) progressive" ";"
-        GST_VIDEO_CAPS_MAKE_WITH_FEATURES (GST_CAPS_FEATURE_MEMORY_DMABUF,
-            "{ NV12 }")));
+    GST_STATIC_CAPS (GST_MSDK_CAPS_STR (COMMON_FORMAT, "NV12")));
 
 static GstStaticPadTemplate src_factory = GST_STATIC_PAD_TEMPLATE ("src",
     GST_PAD_SRC,

--- a/sys/msdk/gstmsdkvpp.c
+++ b/sys/msdk/gstmsdkvpp.c
@@ -85,12 +85,14 @@ GST_DEBUG_CATEGORY_EXTERN (gst_msdkvpp_debug);
 #define DMABUF_SRC_CAPS_STR ""
 #endif
 
-
 static GstStaticPadTemplate gst_msdkvpp_sink_factory =
     GST_STATIC_PAD_TEMPLATE ("sink",
     GST_PAD_SINK,
     GST_PAD_ALWAYS,
     GST_STATIC_CAPS (GST_VIDEO_CAPS_MAKE (SUPPORTED_SYSTEM_FORMAT)
+        ", " "interlace-mode = (string){ progressive, interleaved, mixed }" ";"
+        GST_MSDK_CAPS_MAKE_WITH_FEATURES (GST_CAPS_FEATURE_MEMORY_MSDK_MEMORY,
+            SUPPORTED_SYSTEM_FORMAT)
         ", " "interlace-mode = (string){ progressive, interleaved, mixed }" ";"
         DMABUF_SINK_CAPS_STR));
 
@@ -101,7 +103,11 @@ static GstStaticPadTemplate gst_msdkvpp_src_factory =
     GST_STATIC_CAPS (DMABUF_SRC_CAPS_STR
         GST_VIDEO_CAPS_MAKE ("{ BGRA, NV12, YUY2, UYVY, VUYA, BGRx, P010_10LE"
             EXT_FORMATS "}") ", "
-        "interlace-mode = (string){ progressive, interleaved, mixed }" ";"));
+        "interlace-mode = (string){ progressive, interleaved, mixed }" ";"
+        GST_MSDK_CAPS_MAKE_WITH_FEATURES (GST_CAPS_FEATURE_MEMORY_MSDK_MEMORY,
+            "{ BGRA, NV12, YUY2, UYVY, VUYA, BGRx, P010_10LE"
+            EXT_FORMATS "}") ", "
+        "interlace-mode = (string){ progressive, interleaved, mixed }"));
 
 enum
 {

--- a/sys/msdk/msdk.h
+++ b/sys/msdk/msdk.h
@@ -43,6 +43,13 @@
 
 #include <mfxvideo.h>
 
+/**
+ * GST_CAPS_FEATURE_MEMORY_MSDK_MEMORY:
+ *
+ * Name of the caps feature for indicating the use of msdk video memory
+ */
+#define GST_CAPS_FEATURE_MEMORY_MSDK_MEMORY "memory:MSDKMemory"
+
 G_BEGIN_DECLS
 
 mfxSession msdk_open_session (mfxIMPL impl);
@@ -81,6 +88,26 @@ gst_msdk_update_mfx_frame_info_from_mfx_video_param (mfxFrameInfo * mfx_info,
 void
 gst_msdk_get_mfx_video_orientation_from_video_direction (guint value,
     guint * mfx_mirror, guint * mfx_rotation);
+
+#define GST_MSDK_CAPS_MAKE(format) \
+  GST_VIDEO_CAPS_MAKE (format) ", " \
+  "interlace-mode = (string) progressive"
+
+#define GST_MSDK_CAPS_MAKE_WITH_FEATURES(features,format) \
+  GST_VIDEO_CAPS_MAKE_WITH_FEATURES(features,format) ", " \
+  "interlace-mode = (string) progressive"
+
+#ifndef _WIN32
+#define GST_MSDK_CAPS_DMABUF(dmaformat) \
+  GST_MSDK_CAPS_MAKE_WITH_FEATURES(GST_CAPS_FEATURE_MEMORY_DMABUF, dmaformat)
+#else
+#define GST_MSDK_CAPS_DMABUF(dmaformat) ""
+#endif
+
+#define GST_MSDK_CAPS_STR(format,dmaformat) \
+  GST_MSDK_CAPS_MAKE (format) ";" \
+  GST_MSDK_CAPS_MAKE_WITH_FEATURES (GST_CAPS_FEATURE_MEMORY_MSDK_MEMORY,format) ";" \
+  GST_MSDK_CAPS_DMABUF (dmaformat)
 
 G_END_DECLS
 


### PR DESCRIPTION
```
msdk: Use Video memory only if linked element is also MSDK element

... otherwise use system memory. And never use video memory on Windows
which is not implemented yet.
```

```
msdk: Introduce new caps feature for MSDK

Add new caps feature "memory:MSDKMemory" for target memory type
decision. The MSDK context does not guarantee that linked adjacent
element is also MSDK element (e.g., some filtering element might be
configured between msdk elements)
```
Mirror of https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/merge_requests/655
