### PR TITLE
msdkenc: add an extra surface for hevc encoding

### DIFF
--- a/sys/msdk/gstmsdkh265enc.c
+++ b/sys/msdk/gstmsdkh265enc.c
@@ -271,5 +271,7 @@ gst_msdkh265enc_class_init (GstMsdkH265EncClass * klass)
 static void
 gst_msdkh265enc_init (GstMsdkH265Enc * thiz)
 {
+  GstMsdkEnc *msdk_enc = (GstMsdkEnc *) thiz;
   thiz->lowpower = PROP_LOWPOWER_DEFAULT;
+  msdk_enc->num_extra_frames = 1;
 }


### PR DESCRIPTION
For some hevc 10bit 4K encoding cases, the encoding process may be
slow, and MediaSDK surface can't be released in time before one other
available surface is needed. So add an extra surface for hevc encoding
to avoid this issue.