### PR TITLE
msdk: don't cache mfxFrameAllocResponse pointer

### DIFF
--- a/sys/msdk/gstmsdkallocator_libva.c
+++ b/sys/msdk/gstmsdkallocator_libva.c
@@ -69,10 +69,10 @@ gst_msdk_frame_alloc (mfxHDL pthis, mfxFrameAllocRequest * req,
         gst_msdk_context_get_cached_alloc_responses_by_request (context, req);
     if (cached) {
       /* check if enough frames were allocated */
-      if (req->NumFrameSuggested > cached->response->NumFrameActual)
+      if (req->NumFrameSuggested > cached->response.NumFrameActual)
         return MFX_ERR_MEMORY_ALLOC;
 
-      *resp = *cached->response;
+      *resp = cached->response;
       return MFX_ERR_NONE;
     }
   }
@@ -205,8 +205,7 @@ gst_msdk_frame_alloc (mfxHDL pthis, mfxFrameAllocRequest * req,
   resp->mids = mids;
   resp->NumFrameActual = surfaces_num;
 
-  msdk_resp->response = resp;
-  msdk_resp->mem_ids = mids;
+  msdk_resp->response = *resp;
   msdk_resp->request = *req;
 
   gst_msdk_context_add_alloc_response (context, msdk_resp);

--- a/sys/msdk/gstmsdkcontext.c
+++ b/sys/msdk/gstmsdkcontext.c
@@ -346,7 +346,7 @@ _find_response (gconstpointer resp, gconstpointer comp_resp)
   GstMsdkAllocResponse *cached_resp = (GstMsdkAllocResponse *) resp;
   mfxFrameAllocResponse *_resp = (mfxFrameAllocResponse *) comp_resp;
 
-  return cached_resp ? cached_resp->mem_ids != _resp->mids : -1;
+  return cached_resp ? cached_resp->response.mids != _resp->mids : -1;
 }
 
 static gint
@@ -400,8 +400,8 @@ create_surfaces (GstMsdkContext * context, GstMsdkAllocResponse * resp)
   mfxMemId *mem_id;
   mfxFrameSurface1 *surface;
 
-  for (i = 0; i < resp->response->NumFrameActual; i++) {
-    mem_id = resp->mem_ids[i];
+  for (i = 0; i < resp->response.NumFrameActual; i++) {
+    mem_id = resp->response.mids[i];
     surface = (mfxFrameSurface1 *) g_slice_new0 (mfxFrameSurface1);
     if (!surface) {
       GST_ERROR ("failed to allocate surface");

--- a/sys/msdk/gstmsdkcontext.h
+++ b/sys/msdk/gstmsdkcontext.h
@@ -97,9 +97,8 @@ gint gst_msdk_context_get_fd (GstMsdkContext * context);
 typedef struct _GstMsdkAllocResponse GstMsdkAllocResponse;
 
 struct _GstMsdkAllocResponse {
-  mfxFrameAllocResponse *response;
+  mfxFrameAllocResponse response;
   mfxFrameAllocRequest request;
-  mfxMemId *mem_ids;
   GList *surfaces_avail;
   GList *surfaces_used;
   GList *surfaces_locked;


### PR DESCRIPTION
Otherwise it is possible that different wrappers share the same
mfxFrameAllocResponse pointer, so instead of caching the pointer, we may
cache the content of mfxFrameAllocResponse