### PR TITLE
msdkdec: set pointer to NULL to avoid freeing an used surface

### DIFF
--- a/sys/msdk/gstmsdkdec.c
+++ b/sys/msdk/gstmsdkdec.c
@@ -1067,6 +1067,7 @@ gst_msdkdec_handle_frame (GstVideoDecoder * decoder, GstVideoCodecFrame * frame)
 
       if (bitstream.DataLength == 0) {
         flow = GST_FLOW_OK;
+        surface = NULL;
         break;
       }
     } else if (status == MFX_ERR_MORE_DATA) {


### PR DESCRIPTION
The surface should be cached in the surface list when GST_FLOW_OK is
going to be returned

This fixes https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/issues/1051