### PR TITLE
msdk: ignore MFX_ERR_UNDEFINED_BEHAVIOR when loading a plugin

### DIFF
--- a/sys/msdk/gstmsdkh265dec.c
+++ b/sys/msdk/gstmsdkh265dec.c
@@ -77,7 +77,10 @@ gst_msdkh265dec_configure (GstMsdkDec * decoder)
     uid = &MFX_PLUGINID_HEVCD_SW;
 
   status = MFXVideoUSER_Load (session, uid, 1);
-  if (status < MFX_ERR_NONE) {
+  if (status == MFX_ERR_UNDEFINED_BEHAVIOR) {
+    GST_WARNING_OBJECT (h265dec,
+        "Media SDK Plugin for h265dec has been loaded");
+  } else if (status < MFX_ERR_NONE) {
     GST_ERROR_OBJECT (h265dec, "Media SDK Plugin load failed (%s)",
         msdk_status_to_string (status));
     return FALSE;

--- a/sys/msdk/gstmsdkh265enc.c
+++ b/sys/msdk/gstmsdkh265enc.c
@@ -102,7 +102,10 @@ gst_msdkh265enc_configure (GstMsdkEnc * encoder)
     uid = &MFX_PLUGINID_HEVCE_SW;
 
   status = MFXVideoUSER_Load (session, uid, 1);
-  if (status < MFX_ERR_NONE) {
+  if (status == MFX_ERR_UNDEFINED_BEHAVIOR) {
+    GST_WARNING_OBJECT (h265enc,
+        "Media SDK Plugin for h265enc has been loaded");
+  } else if (status < MFX_ERR_NONE) {
     GST_ERROR_OBJECT (h265enc, "Media SDK Plugin load failed (%s)",
         msdk_status_to_string (status));
     return FALSE;

--- a/sys/msdk/gstmsdkvp8dec.c
+++ b/sys/msdk/gstmsdkvp8dec.c
@@ -64,7 +64,9 @@ gst_msdkvp8dec_configure (GstMsdkDec * decoder)
   uid = &MFX_PLUGINID_VP8D_HW;
 
   status = MFXVideoUSER_Load (session, uid, 1);
-  if (status < MFX_ERR_NONE) {
+  if (status == MFX_ERR_UNDEFINED_BEHAVIOR) {
+    GST_WARNING_OBJECT (vp8dec, "Media SDK Plugin for vp8dec has been loaded");
+  } else if (status < MFX_ERR_NONE) {
     GST_ERROR_OBJECT (vp8dec, "Media SDK Plugin load failed (%s)",
         msdk_status_to_string (status));
     return FALSE;

--- a/sys/msdk/gstmsdkvp9dec.c
+++ b/sys/msdk/gstmsdkvp9dec.c
@@ -74,7 +74,9 @@ gst_msdkvp9dec_configure (GstMsdkDec * decoder)
   uid = &MFX_PLUGINID_VP9D_HW;
 
   status = MFXVideoUSER_Load (session, uid, 1);
-  if (status < MFX_ERR_NONE) {
+  if (status == MFX_ERR_UNDEFINED_BEHAVIOR) {
+    GST_WARNING_OBJECT (vp9dec, "Media SDK Plugin for vp9dec has been loaded");
+  } else if (status < MFX_ERR_NONE) {
     GST_ERROR_OBJECT (vp9dec, "Media SDK Plugin load failed (%s)",
         msdk_status_to_string (status));
     return FALSE;

--- a/sys/msdk/gstmsdkvp9enc.c
+++ b/sys/msdk/gstmsdkvp9enc.c
@@ -121,7 +121,9 @@ gst_msdkvp9enc_configure (GstMsdkEnc * encoder)
     session = gst_msdk_context_get_session (encoder->context);
     status = MFXVideoUSER_Load (session, &MFX_PLUGINID_VP9E_HW, 1);
 
-    if (status < MFX_ERR_NONE) {
+    if (status == MFX_ERR_UNDEFINED_BEHAVIOR) {
+      GST_WARNING_OBJECT (thiz, "Media SDK Plugin for vp9enc has been loaded");
+    } else if (status < MFX_ERR_NONE) {
       GST_ERROR_OBJECT (thiz, "Media SDK Plugin load failed (%s)",
           msdk_status_to_string (status));
       return FALSE;


### PR DESCRIPTION
An issue can be seen when using msdkh265enc with bitrate change in
playing state. The root cause is the corresponding plugin is loaded
again.

Returning MFX_ERR_UNDEFINED_BEHAVIOR from MSDK just means the plugin has
been loaded, so we may ignore this error when doing configuation again
in the sub class, otherwise the pipeline will be interrupted