### PR TITLE
msdk: ignore MFX_ERR_UNDEFINED_BEHAVIOR when loading a plugin

### DIFF
--- a/sys/msdk/gstmsdkh265dec.c
+++ b/sys/msdk/gstmsdkh265dec.c
@@ -33,8 +33,6 @@
 #  include <config.h>
 #endif
 
-#include <mfxplugin.h>
-
 #include "gstmsdkh265dec.h"
 #include "gstmsdkvideomemory.h"
 
@@ -66,7 +64,6 @@ gst_msdkh265dec_configure (GstMsdkDec * decoder)
 {
   GstMsdkH265Dec *h265dec = GST_MSDKH265DEC (decoder);
   mfxSession session;
-  mfxStatus status;
   const mfxPluginUID *uid;
 
   session = gst_msdk_context_get_session (decoder->context);
@@ -76,15 +73,8 @@ gst_msdkh265dec_configure (GstMsdkDec * decoder)
   else
     uid = &MFX_PLUGINID_HEVCD_SW;
 
-  status = MFXVideoUSER_Load (session, uid, 1);
-  if (status < MFX_ERR_NONE) {
-    GST_ERROR_OBJECT (h265dec, "Media SDK Plugin load failed (%s)",
-        msdk_status_to_string (status));
+  if (!gst_msdk_load_plugin (session, uid, 1, "msdkh265dec"))
     return FALSE;
-  } else if (status > MFX_ERR_NONE) {
-    GST_WARNING_OBJECT (h265dec, "Media SDK Plugin load warning: %s",
-        msdk_status_to_string (status));
-  }
 
   decoder->param.mfx.CodecId = MFX_CODEC_HEVC;
 

--- a/sys/msdk/gstmsdkh265enc.c
+++ b/sys/msdk/gstmsdkh265enc.c
@@ -33,8 +33,6 @@
 #  include <config.h>
 #endif
 
-#include <mfxplugin.h>
-
 #include <gst/allocators/gstdmabuf.h>
 
 #include "gstmsdkh265enc.h"
@@ -91,7 +89,6 @@ gst_msdkh265enc_configure (GstMsdkEnc * encoder)
 {
   GstMsdkH265Enc *h265enc = GST_MSDKH265ENC (encoder);
   mfxSession session;
-  mfxStatus status;
   const mfxPluginUID *uid;
 
   session = gst_msdk_context_get_session (encoder->context);
@@ -101,15 +98,8 @@ gst_msdkh265enc_configure (GstMsdkEnc * encoder)
   else
     uid = &MFX_PLUGINID_HEVCE_SW;
 
-  status = MFXVideoUSER_Load (session, uid, 1);
-  if (status < MFX_ERR_NONE) {
-    GST_ERROR_OBJECT (h265enc, "Media SDK Plugin load failed (%s)",
-        msdk_status_to_string (status));
+  if (!gst_msdk_load_plugin (session, uid, 1, "msdkh265enc"))
     return FALSE;
-  } else if (status > MFX_ERR_NONE) {
-    GST_WARNING_OBJECT (h265enc, "Media SDK Plugin load warning: %s",
-        msdk_status_to_string (status));
-  }
 
   encoder->param.mfx.CodecId = MFX_CODEC_HEVC;
 

--- a/sys/msdk/gstmsdkvp8dec.c
+++ b/sys/msdk/gstmsdkvp8dec.c
@@ -34,10 +34,9 @@
 #  include <config.h>
 #endif
 
-#include <mfxplugin.h>
-#include <mfxvp8.h>
-
 #include "gstmsdkvp8dec.h"
+
+#include <mfxvp8.h>
 
 GST_DEBUG_CATEGORY_EXTERN (gst_msdkvp8dec_debug);
 #define GST_CAT_DEFAULT gst_msdkvp8dec_debug
@@ -56,22 +55,14 @@ gst_msdkvp8dec_configure (GstMsdkDec * decoder)
 {
   GstMsdkVP8Dec *vp8dec = GST_MSDKVP8DEC (decoder);
   mfxSession session;
-  mfxStatus status;
   const mfxPluginUID *uid;
 
   session = gst_msdk_context_get_session (decoder->context);
 
   uid = &MFX_PLUGINID_VP8D_HW;
 
-  status = MFXVideoUSER_Load (session, uid, 1);
-  if (status < MFX_ERR_NONE) {
-    GST_ERROR_OBJECT (vp8dec, "Media SDK Plugin load failed (%s)",
-        msdk_status_to_string (status));
+  if (!gst_msdk_load_plugin (session, uid, 1, "msdkvp8dec"))
     return FALSE;
-  } else if (status > MFX_ERR_NONE) {
-    GST_WARNING_OBJECT (vp8dec, "Media SDK Plugin load warning: %s",
-        msdk_status_to_string (status));
-  }
 
   decoder->param.mfx.CodecId = MFX_CODEC_VP8;
   /* Replaced with width and height rounded up to 16 */

--- a/sys/msdk/gstmsdkvp9dec.c
+++ b/sys/msdk/gstmsdkvp9dec.c
@@ -35,7 +35,6 @@
 #  include <config.h>
 #endif
 
-#include <mfxplugin.h>
 #include <mfxvp9.h>
 
 #include "gstmsdkvp9dec.h"
@@ -66,22 +65,14 @@ gst_msdkvp9dec_configure (GstMsdkDec * decoder)
 {
   GstMsdkVP9Dec *vp9dec = GST_MSDKVP9DEC (decoder);
   mfxSession session;
-  mfxStatus status;
   const mfxPluginUID *uid;
 
   session = gst_msdk_context_get_session (decoder->context);
 
   uid = &MFX_PLUGINID_VP9D_HW;
 
-  status = MFXVideoUSER_Load (session, uid, 1);
-  if (status < MFX_ERR_NONE) {
-    GST_ERROR_OBJECT (vp9dec, "Media SDK Plugin load failed (%s)",
-        msdk_status_to_string (status));
+  if (!gst_msdk_load_plugin (session, uid, 1, "msdkvp9dec"))
     return FALSE;
-  } else if (status > MFX_ERR_NONE) {
-    GST_WARNING_OBJECT (vp9dec, "Media SDK Plugin load warning: %s",
-        msdk_status_to_string (status));
-  }
 
   decoder->param.mfx.CodecId = MFX_CODEC_VP9;
   /* Replaced with width and height rounded up to 16 */

--- a/sys/msdk/gstmsdkvp9enc.c
+++ b/sys/msdk/gstmsdkvp9enc.c
@@ -33,8 +33,6 @@
 #  include <config.h>
 #endif
 
-#include <mfxplugin.h>
-
 #include <gst/allocators/gstdmabuf.h>
 
 #include "gstmsdkvp9enc.h"
@@ -115,20 +113,12 @@ gst_msdkvp9enc_configure (GstMsdkEnc * encoder)
 {
   GstMsdkVP9Enc *thiz = GST_MSDKVP9ENC (encoder);
   mfxSession session;
-  mfxStatus status;
 
   if (encoder->hardware) {
     session = gst_msdk_context_get_session (encoder->context);
-    status = MFXVideoUSER_Load (session, &MFX_PLUGINID_VP9E_HW, 1);
 
-    if (status < MFX_ERR_NONE) {
-      GST_ERROR_OBJECT (thiz, "Media SDK Plugin load failed (%s)",
-          msdk_status_to_string (status));
+    if (!gst_msdk_load_plugin (session, &MFX_PLUGINID_VP9E_HW, 1, "msdkvp9enc"))
       return FALSE;
-    } else if (status > MFX_ERR_NONE) {
-      GST_WARNING_OBJECT (thiz, "Media SDK Plugin load warning: %s",
-          msdk_status_to_string (status));
-    }
   }
 
   encoder->num_extra_frames = encoder->async_depth - 1;

--- a/sys/msdk/msdk.c
+++ b/sys/msdk/msdk.c
@@ -450,3 +450,25 @@ gst_msdk_get_mfx_video_orientation_from_video_direction (guint value,
       break;
   }
 }
+
+gboolean
+gst_msdk_load_plugin (mfxSession session, const mfxPluginUID * uid,
+    mfxU32 version, const gchar * plugin)
+{
+  mfxStatus status;
+
+  status = MFXVideoUSER_Load (session, uid, version);
+
+  if (status == MFX_ERR_UNDEFINED_BEHAVIOR) {
+    GST_WARNING ("Media SDK Plugin for %s has been loaded", plugin);
+  } else if (status < MFX_ERR_NONE) {
+    GST_ERROR ("Media SDK Plugin for %s load failed (%s)", plugin,
+        msdk_status_to_string (status));
+    return FALSE;
+  } else if (status > MFX_ERR_NONE) {
+    GST_WARNING ("Media SDK Plugin for %s load warning: %s", plugin,
+        msdk_status_to_string (status));
+  }
+
+  return TRUE;
+}

--- a/sys/msdk/msdk.h
+++ b/sys/msdk/msdk.h
@@ -43,6 +43,7 @@
 #include <gst/allocators/allocators.h>
 
 #include <mfxvideo.h>
+#include <mfxplugin.h>
 
 G_BEGIN_DECLS
 
@@ -98,6 +99,10 @@ gst_msdk_update_mfx_frame_info_from_mfx_video_param (mfxFrameInfo * mfx_info,
 void
 gst_msdk_get_mfx_video_orientation_from_video_direction (guint value,
     guint * mfx_mirror, guint * mfx_rotation);
+
+gboolean
+gst_msdk_load_plugin (mfxSession session, const mfxPluginUID * uid,
+    mfxU32 version, const gchar * plugin);
 
 G_END_DECLS
 


### PR DESCRIPTION
An issue can be seen when using msdkh265enc with bitrate change in
playing state. The root cause is the corresponding plugin is loaded
again.

Returning MFX_ERR_UNDEFINED_BEHAVIOR from MSDK just means the plugin has
been loaded, so we may ignore this error when doing configuation again
in the sub class, otherwise the pipeline will be interrupted