### PR TITLE
msdkdec: free unlocked msdk surface before output buffer allocation

### DIFF
--- a/sys/msdk/gstmsdkdec.c
+++ b/sys/msdk/gstmsdkdec.c
@@ -681,18 +681,18 @@ gst_msdkdec_start (GstVideoDecoder * decoder)
 {
   GstMsdkDec *thiz = GST_MSDKDEC (decoder);
 
+  /* TODO: Currently d3d allocator is not implemented.
+   * So decoder uses system memory by default on Windows.
+   */
+#ifndef _WIN32
+  thiz->use_video_memory = TRUE;
+#else
+  thiz->use_video_memory = FALSE;
+#endif
+
   if (gst_msdk_context_prepare (GST_ELEMENT_CAST (thiz), &thiz->context)) {
     GST_INFO_OBJECT (thiz, "Found context %" GST_PTR_FORMAT " from neighbour",
         thiz->context);
-
-    /* TODO: Currently d3d allocator is not implemented.
-     * So decoder uses system memory by default on Windows.
-     */
-#ifndef _WIN32
-    thiz->use_video_memory = TRUE;
-#else
-    thiz->use_video_memory = FALSE;
-#endif
 
     if (gst_msdk_context_get_job_type (thiz->context) & GST_MSDK_JOB_DECODER) {
       GstMsdkContext *parent_context, *msdk_context;


### PR DESCRIPTION
https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/merge_requests/924
is trying to use video memory for decoding on Linux, which reveals a
hidden bug in msdkdec.

For video memory, it is possible that a locked mfx surface is not used
indeed and it will be un-locked later in MSDK, so we have to check the
associated MSDK surface to find out and free un-used surfaces, otherwise
it is easy to exhaust all pre-allocated mfx surfaces and get errors below:

0:00:00.777324879 27290 0x564b65a510a0 ERROR                default
gstmsdkvideomemory.c:77:gst_msdk_video_allocator_get_surface: failed to
get surface available
0:00:00.777429079 27290 0x564b65a510a0 ERROR         msdkbufferpool
gstmsdkbufferpool.c:260:gst_msdk_buffer_pool_alloc_buffer:<msdkbufferpool0>
failed to create new MSDK memory

Note the sample code in MSDK does similar thing in
CBuffering::SyncFrameSurfaces()