### PR TITLE
msdk: use cached response for DMABuf when the frame size is same

### DIFF
--- a/sys/msdk/gstmsdkcontext.c
+++ b/sys/msdk/gstmsdkcontext.c
@@ -356,9 +356,13 @@ _find_request (gconstpointer resp, gconstpointer req)
   mfxFrameAllocRequest *_req = (mfxFrameAllocRequest *) req;
 
   /* Confirm if it's under the size of the cached response */
-  if (_req->Info.Width <= cached_resp->request.Info.Width &&
-      _req->Info.Height <= cached_resp->request.Info.Height &&
-      _req->NumFrameSuggested <= cached_resp->request.NumFrameSuggested) {
+  if (_req->NumFrameSuggested <= cached_resp->request.NumFrameSuggested &&
+      (((_req->Type & MFX_MEMTYPE_EXPORT_FRAME) &&
+              _req->Info.Width == cached_resp->request.Info.Width &&
+              _req->Info.Height == cached_resp->request.Info.Height) ||
+          (!(_req->Type & MFX_MEMTYPE_EXPORT_FRAME) &&
+              _req->Info.Width <= cached_resp->request.Info.Width &&
+              _req->Info.Height <= cached_resp->request.Info.Height))) {
     return _req->Type & cached_resp->
         request.Type & MFX_MEMTYPE_FROM_DECODE ? 0 : -1;
   }


### PR DESCRIPTION
User is seeing corrupted display when running `videotestsrc !
video/x-raw,format=NV12,width=xxx,height=xxx ! msdkh265enc ! msdkh265dec
! glimagesink` with changed frame size, e.g. from 1920x1080 to 1920x240

The root cause is a same dmabuf fd is used for frames with
different size, which causes some unexpected result. This patch requires
cached response is used for frames with same size only for DMABuf, so a
dmabuf fd can't be used for frames with different size any more.