### PR TITLE
Fix msdkenc leak on windows

### DIFF
--- a/sys/msdk/gstmsdkcontextutil.c
+++ b/sys/msdk/gstmsdkcontextutil.c
@@ -161,6 +161,7 @@ gst_msdk_context_find (GstElement * element, GstMsdkContext ** context_ptr)
     return TRUE;
   }
 
+  /* This may indirectly set *context_ptr, see function body */
   _gst_context_query (element, GST_MSDK_CONTEXT_TYPE_NAME);
 
   if (*context_ptr)

--- a/sys/msdk/gstmsdkcontextutil.c
+++ b/sys/msdk/gstmsdkcontextutil.c
@@ -147,7 +147,7 @@ found:
 }
 
 gboolean
-gst_msdk_context_prepare (GstElement * element, GstMsdkContext ** context_ptr)
+gst_msdk_context_find (GstElement * element, GstMsdkContext ** context_ptr)
 {
   g_return_val_if_fail (element != NULL, FALSE);
   g_return_val_if_fail (context_ptr != NULL, FALSE);

--- a/sys/msdk/gstmsdkcontextutil.h
+++ b/sys/msdk/gstmsdkcontextutil.h
@@ -44,7 +44,7 @@
 G_BEGIN_DECLS
 
 gboolean
-gst_msdk_context_prepare (GstElement * element, GstMsdkContext ** context_ptr);
+gst_msdk_context_find (GstElement * element, GstMsdkContext ** context_ptr);
 
 gboolean
 gst_msdk_context_get_context (GstContext * context, GstMsdkContext ** msdk_context);

--- a/sys/msdk/gstmsdkdec.c
+++ b/sys/msdk/gstmsdkdec.c
@@ -710,6 +710,12 @@ gst_msdkdec_context_prepare (GstMsdkDec * thiz)
   if (!gst_msdk_context_find (GST_ELEMENT_CAST (thiz), &thiz->context))
     return FALSE;
 
+  if (thiz->context == thiz->old_context) {
+    GST_INFO_OBJECT (thiz, "Found old context %" GST_PTR_FORMAT
+        ", reusing as-is", thiz->context);
+    return TRUE;
+  }
+
   /* TODO: Currently d3d allocator is not implemented.
    * So decoder uses system memory by default on Windows.
    */
@@ -764,6 +770,11 @@ gst_msdkdec_start (GstVideoDecoder * decoder)
     GST_INFO_OBJECT (thiz, "Creating new context %" GST_PTR_FORMAT,
         thiz->context);
   }
+
+  /* Save the current context in a separate field so that we know whether it
+   * has changed between calls to _start() */
+  gst_object_replace ((GstObject **) & thiz->old_context,
+      (GstObject *) thiz->context);
 
   gst_msdk_context_add_shared_async_depth (thiz->context, thiz->async_depth);
 

--- a/sys/msdk/gstmsdkdec.c
+++ b/sys/msdk/gstmsdkdec.c
@@ -761,8 +761,7 @@ gst_msdkdec_close (GstVideoDecoder * decoder)
 {
   GstMsdkDec *thiz = GST_MSDKDEC (decoder);
 
-  if (thiz->context)
-    gst_object_replace ((GstObject **) & thiz->context, NULL);
+  gst_clear_object (&thiz->context);
 
   return TRUE;
 }
@@ -1375,8 +1374,7 @@ gst_msdkdec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
   if (thiz->do_realloc || !thiz->pool) {
     GstVideoCodecState *output_state =
         gst_video_decoder_get_output_state (GST_VIDEO_DECODER (thiz));
-    if (thiz->pool)
-      gst_object_replace ((GstObject **) & thiz->pool, NULL);
+    gst_clear_object (&thiz->pool);
     GST_INFO_OBJECT (decoder, "create new MSDK bufferpool");
     thiz->pool =
         gst_msdkdec_create_buffer_pool (thiz, &output_state->info, min_buffers);
@@ -1612,7 +1610,8 @@ gst_msdkdec_finalize (GObject * object)
   GstMsdkDec *thiz = GST_MSDKDEC (object);
 
   g_array_unref (thiz->tasks);
-  g_object_unref (thiz->adapter);
+  thiz->tasks = NULL;
+  g_clear_object (&thiz->adapter);
 
   /* NULL is the empty list. */
   if (G_UNLIKELY (thiz->decoded_msdk_surfaces != NULL)) {

--- a/sys/msdk/gstmsdkdec.h
+++ b/sys/msdk/gstmsdkdec.h
@@ -90,6 +90,7 @@ struct _GstMsdkDec
 
   /* MFX context */
   GstMsdkContext *context;
+  GstMsdkContext *old_context;
   mfxVideoParam param;
   GArray *tasks;
   guint next_task;

--- a/sys/msdk/gstmsdkenc.c
+++ b/sys/msdk/gstmsdkenc.c
@@ -1411,7 +1411,9 @@ gst_msdkenc_get_surface_from_frame (GstMsdkEnc * thiz,
   GstVideoFrame src_frame, out_frame;
   MsdkSurface *msdk_surface;
   GstBuffer *inbuf;
+#ifndef _WIN32
   GstMemory *mem = NULL;
+#endif
 
   inbuf = frame->input_buffer;
   if (gst_msdk_is_msdk_buffer (inbuf)) {

--- a/sys/msdk/gstmsdkenc.c
+++ b/sys/msdk/gstmsdkenc.c
@@ -700,8 +700,8 @@ gst_msdkenc_close_encoder (GstMsdkEnc * thiz)
   GST_DEBUG_OBJECT (thiz, "Closing encoder with context %" GST_PTR_FORMAT,
       thiz->context);
 
-  gst_object_replace ((GstObject **) & thiz->msdk_pool, NULL);
-  gst_object_replace ((GstObject **) & thiz->msdk_converted_pool, NULL);
+  gst_clear_object (&thiz->msdk_pool);
+  gst_clear_object (&thiz->msdk_converted_pool);
 
   if (thiz->use_video_memory)
     gst_msdk_frame_free (thiz->context, &thiz->alloc_resp);
@@ -1295,7 +1295,7 @@ gst_msdkenc_set_format (GstVideoEncoder * encoder, GstVideoCodecState * state)
         goto done;
       }
       /* Release current pool because we are going to create a new one */
-      gst_object_replace ((GstObject **) & thiz->msdk_converted_pool, NULL);
+      gst_clear_object (&thiz->msdk_converted_pool);
     }
 
     /* Otherwise create a new pool */
@@ -1662,7 +1662,7 @@ gst_msdkenc_stop (GstVideoEncoder * encoder)
     gst_video_codec_state_unref (thiz->input_state);
   thiz->input_state = NULL;
 
-  gst_object_replace ((GstObject **) & thiz->context, NULL);
+  gst_clear_object (&thiz->context);
 
   return TRUE;
 }
@@ -1760,8 +1760,8 @@ gst_msdkenc_finalize (GObject * object)
     gst_video_codec_state_unref (thiz->input_state);
   thiz->input_state = NULL;
 
-  gst_object_replace ((GstObject **) & thiz->msdk_pool, NULL);
-  gst_object_replace ((GstObject **) & thiz->msdk_converted_pool, NULL);
+  gst_clear_object (&thiz->msdk_pool);
+  gst_clear_object (&thiz->msdk_converted_pool);
 
   G_OBJECT_CLASS (parent_class)->finalize (object);
 }

--- a/sys/msdk/gstmsdkenc.c
+++ b/sys/msdk/gstmsdkenc.c
@@ -1605,6 +1605,12 @@ gst_msdkenc_context_prepare (GstMsdkEnc * thiz)
   if (!gst_msdk_context_find (GST_ELEMENT_CAST (thiz), &thiz->context))
     return FALSE;
 
+  if (thiz->context == thiz->old_context) {
+    GST_INFO_OBJECT (thiz, "Found old context %" GST_PTR_FORMAT
+        ", reusing as-is", thiz->context);
+    return TRUE;
+  }
+
   GST_INFO_OBJECT (thiz, "Found context %" GST_PTR_FORMAT " from neighbour",
       thiz->context);
 
@@ -1655,6 +1661,11 @@ gst_msdkenc_start (GstVideoEncoder * encoder)
     GST_INFO_OBJECT (thiz, "Creating new context %" GST_PTR_FORMAT,
         thiz->context);
   }
+
+  /* Save the current context in a separate field so that we know whether it
+   * has changed between calls to _start() */
+  gst_object_replace ((GstObject **) & thiz->old_context,
+      (GstObject *) thiz->context);
 
   gst_msdk_context_add_shared_async_depth (thiz->context, thiz->async_depth);
 
@@ -1779,6 +1790,7 @@ gst_msdkenc_finalize (GObject * object)
 
   gst_clear_object (&thiz->msdk_pool);
   gst_clear_object (&thiz->msdk_converted_pool);
+  gst_clear_object (&thiz->old_context);
 
   G_OBJECT_CLASS (parent_class)->finalize (object);
 }

--- a/sys/msdk/gstmsdkenc.c
+++ b/sys/msdk/gstmsdkenc.c
@@ -1598,42 +1598,57 @@ invalid_frame:
 }
 
 static gboolean
+gst_msdkenc_context_prepare (GstMsdkEnc * thiz)
+{
+  /* Try to find an existing context from the pipeline. This may (indirectly)
+   * invoke gst_msdkenc_set_context, which will set thiz->context. */
+  if (!gst_msdk_context_find (GST_ELEMENT_CAST (thiz), &thiz->context))
+    return FALSE;
+
+  GST_INFO_OBJECT (thiz, "Found context %" GST_PTR_FORMAT " from neighbour",
+      thiz->context);
+
+  /* Check GST_MSDK_JOB_VPP and GST_MSDK_JOB_ENCODER together to avoid sharing context
+   * between VPP and ENCODER
+   * Example:
+   * gst-launch-1.0 videotestsrc ! video/x-raw,format=I420 ! msdkh264enc ! \
+   * msdkh264dec ! msdkvpp ! video/x-raw,format=YUY2 ! fakesink
+   */
+  if (!gst_msdk_context_get_job_type (thiz->context) & (GST_MSDK_JOB_VPP |
+          GST_MSDK_JOB_ENCODER)) {
+    gst_msdk_context_add_job_type (thiz->context, GST_MSDK_JOB_ENCODER);
+    return TRUE;
+  }
+
+  /* Found an existing context that's already being used as an encoder, clone
+   * the MFX session inside it to create a new one */
+  {
+    GstMsdkContext *parent_context, *msdk_context;
+
+    GST_INFO_OBJECT (thiz, "Creating new context %" GST_PTR_FORMAT " with "
+        "joined session", thiz->context);
+    parent_context = thiz->context;
+    msdk_context = gst_msdk_context_new_with_parent (parent_context);
+
+    if (!msdk_context) {
+      GST_ERROR_OBJECT (thiz, "Failed to create a context with parent context "
+          "as %" GST_PTR_FORMAT, parent_context);
+      return FALSE;
+    }
+
+    thiz->context = msdk_context;
+    gst_object_unref (parent_context);
+  }
+
+  return TRUE;
+}
+
+static gboolean
 gst_msdkenc_start (GstVideoEncoder * encoder)
 {
   GstMsdkEnc *thiz = GST_MSDKENC (encoder);
 
-  if (gst_msdk_context_prepare (GST_ELEMENT_CAST (thiz), &thiz->context)) {
-    GST_INFO_OBJECT (thiz, "Found context %" GST_PTR_FORMAT " from neighbour",
-        thiz->context);
-
-    /* Check GST_MSDK_JOB_VPP and GST_MSDK_JOB_ENCODER together to avoid sharing context
-     * between VPP and ENCODER
-     * Example:
-     * gst-launch-1.0 videotestsrc ! video/x-raw,format=I420 ! msdkh264enc ! \
-     * msdkh264dec ! msdkvpp ! video/x-raw,format=YUY2 ! fakesink
-     */
-    if (gst_msdk_context_get_job_type (thiz->context) & (GST_MSDK_JOB_VPP |
-            GST_MSDK_JOB_ENCODER)) {
-      GstMsdkContext *parent_context, *msdk_context;
-
-      parent_context = thiz->context;
-      msdk_context = gst_msdk_context_new_with_parent (parent_context);
-
-      if (!msdk_context) {
-        GST_ERROR_OBJECT (thiz, "Context creation failed");
-        return FALSE;
-      }
-
-      thiz->context = msdk_context;
-      gst_object_unref (parent_context);
-
-      GST_INFO_OBJECT (thiz,
-          "Creating new context %" GST_PTR_FORMAT " with joined session",
-          thiz->context);
-    } else {
-      gst_msdk_context_add_job_type (thiz->context, GST_MSDK_JOB_ENCODER);
-    }
-  } else {
+  if (!gst_msdkenc_context_prepare (thiz)) {
     if (!gst_msdk_context_ensure_context (GST_ELEMENT_CAST (thiz),
             thiz->hardware, GST_MSDK_JOB_ENCODER))
       return FALSE;

--- a/sys/msdk/gstmsdkenc.h
+++ b/sys/msdk/gstmsdkenc.h
@@ -99,6 +99,7 @@ struct _GstMsdkEnc
 
   /* MFX context */
   GstMsdkContext *context;
+  GstMsdkContext *old_context;
   mfxVideoParam param;
   guint num_surfaces;
   guint num_tasks;

--- a/sys/msdk/gstmsdkvpp.c
+++ b/sys/msdk/gstmsdkvpp.c
@@ -650,7 +650,9 @@ get_msdk_surface_from_input_buffer (GstMsdkVPP * thiz, GstBuffer * inbuf)
 {
   GstVideoFrame src_frame, out_frame;
   MsdkSurface *msdk_surface;
+#ifndef _WIN32
   GstMemory *mem = NULL;
+#endif
 
   if (gst_msdk_is_msdk_buffer (inbuf)) {
     msdk_surface = g_slice_new0 (MsdkSurface);

--- a/sys/msdk/gstmsdkvpp.c
+++ b/sys/msdk/gstmsdkvpp.c
@@ -197,6 +197,12 @@ gst_msdkvpp_context_prepare (GstMsdkVPP * thiz)
   if (!gst_msdk_context_find (GST_ELEMENT_CAST (thiz), &thiz->context))
     return FALSE;
 
+  if (thiz->context == thiz->old_context) {
+    GST_INFO_OBJECT (thiz, "Found old context %" GST_PTR_FORMAT
+        ", reusing as-is", thiz->context);
+    return TRUE;
+  }
+
   GST_INFO_OBJECT (thiz, "Found context %" GST_PTR_FORMAT " from neighbour",
       thiz->context);
 
@@ -246,6 +252,11 @@ ensure_context (GstBaseTransform * trans)
     GST_INFO_OBJECT (thiz, "Creating new context %" GST_PTR_FORMAT,
         thiz->context);
   }
+
+  /* Save the current context in a separate field so that we know whether it
+   * has changed between calls to _start() */
+  gst_object_replace ((GstObject **) & thiz->old_context,
+      (GstObject *) thiz->context);
 
   gst_msdk_context_add_shared_async_depth (thiz->context, thiz->async_depth);
 
@@ -1476,6 +1487,10 @@ gst_msdkvpp_get_property (GObject * object, guint prop_id,
 static void
 gst_msdkvpp_finalize (GObject * object)
 {
+  GstMsdkVPP *thiz = GST_MSDKVPP (object);
+
+  gst_clear_object (&thiz->old_context);
+
   G_OBJECT_CLASS (parent_class)->finalize (object);
 }
 

--- a/sys/msdk/gstmsdkvpp.c
+++ b/sys/msdk/gstmsdkvpp.c
@@ -190,41 +190,56 @@ gst_msdkvpp_add_extra_param (GstMsdkVPP * thiz, mfxExtBuffer * param)
 }
 
 static gboolean
+gst_msdkvpp_context_prepare (GstMsdkVPP * thiz)
+{
+  /* Try to find an existing context from the pipeline. This may (indirectly)
+   * invoke gst_msdkvpp_set_context, which will set thiz->context. */
+  if (!gst_msdk_context_find (GST_ELEMENT_CAST (thiz), &thiz->context))
+    return FALSE;
+
+  GST_INFO_OBJECT (thiz, "Found context %" GST_PTR_FORMAT " from neighbour",
+      thiz->context);
+
+  /* Check GST_MSDK_JOB_VPP and GST_MSDK_JOB_ENCODER together to avoid sharing context
+   * between VPP and ENCODER
+   * Example:
+   * gst-launch-1.0 videotestsrc ! msdkvpp ! video/x-raw,format=YUY2 ! msdkh264enc ! fakesink
+   */
+  if (!gst_msdk_context_get_job_type (thiz->context) & (GST_MSDK_JOB_VPP |
+          GST_MSDK_JOB_ENCODER)) {
+    gst_msdk_context_add_job_type (thiz->context, GST_MSDK_JOB_VPP);
+    return TRUE;
+  }
+
+  /* Found an existing context that's already being used as VPP, so clone the
+   * MFX session inside it to create a new one */
+  {
+    GstMsdkContext *parent_context, *msdk_context;
+
+    GST_INFO_OBJECT (thiz, "Creating new context %" GST_PTR_FORMAT " with "
+        "joined session", thiz->context);
+    parent_context = thiz->context;
+    msdk_context = gst_msdk_context_new_with_parent (parent_context);
+
+    if (!msdk_context) {
+      GST_ERROR_OBJECT (thiz, "Failed to create a context with parent context "
+          "as %" GST_PTR_FORMAT, parent_context);
+      return FALSE;
+    }
+
+    thiz->context = msdk_context;
+    gst_object_unref (parent_context);
+  }
+
+  return TRUE;
+}
+
+static gboolean
 ensure_context (GstBaseTransform * trans)
 {
   GstMsdkVPP *thiz = GST_MSDKVPP (trans);
 
-  if (gst_msdk_context_prepare (GST_ELEMENT_CAST (thiz), &thiz->context)) {
-    GST_INFO_OBJECT (thiz, "Found context from neighbour %" GST_PTR_FORMAT,
-        thiz->context);
-
-    /* Check GST_MSDK_JOB_VPP and GST_MSDK_JOB_ENCODER together to avoid sharing context
-     * between VPP and ENCODER
-     * Example:
-     * gst-launch-1.0 videotestsrc ! msdkvpp ! video/x-raw,format=YUY2 ! msdkh264enc ! fakesink
-     */
-    if (gst_msdk_context_get_job_type (thiz->context) & (GST_MSDK_JOB_ENCODER |
-            GST_MSDK_JOB_VPP)) {
-      GstMsdkContext *parent_context, *msdk_context;
-
-      parent_context = thiz->context;
-      msdk_context = gst_msdk_context_new_with_parent (parent_context);
-
-      if (!msdk_context) {
-        GST_ERROR_OBJECT (thiz, "Context creation failed");
-        return FALSE;
-      }
-
-      thiz->context = msdk_context;
-      gst_object_unref (parent_context);
-
-      GST_INFO_OBJECT (thiz,
-          "Creating new context %" GST_PTR_FORMAT " with joined session",
-          thiz->context);
-    } else {
-      gst_msdk_context_add_job_type (thiz->context, GST_MSDK_JOB_VPP);
-    }
-  } else {
+  if (!gst_msdkvpp_context_prepare (thiz)) {
     if (!gst_msdk_context_ensure_context (GST_ELEMENT_CAST (thiz),
             thiz->hardware, GST_MSDK_JOB_VPP))
       return FALSE;

--- a/sys/msdk/gstmsdkvpp.c
+++ b/sys/msdk/gstmsdkvpp.c
@@ -850,17 +850,12 @@ gst_msdkvpp_close (GstMsdkVPP * thiz)
         msdk_status_to_string (status));
   }
 
-  if (thiz->context)
-    gst_object_replace ((GstObject **) & thiz->context, NULL);
+  gst_clear_object (&thiz->context);
 
   memset (&thiz->param, 0, sizeof (thiz->param));
 
-  if (thiz->sinkpad_buffer_pool)
-    gst_object_unref (thiz->sinkpad_buffer_pool);
-  thiz->sinkpad_buffer_pool = NULL;
-  if (thiz->srcpad_buffer_pool)
-    gst_object_unref (thiz->srcpad_buffer_pool);
-  thiz->srcpad_buffer_pool = NULL;
+  gst_clear_object (&thiz->sinkpad_buffer_pool);
+  gst_clear_object (&thiz->srcpad_buffer_pool);
 
   thiz->buffer_duration = GST_CLOCK_TIME_NONE;
   gst_video_info_init (&thiz->sinkpad_info);
@@ -1105,8 +1100,7 @@ gst_msdkvpp_initialize (GstMsdkVPP * thiz)
 
 no_vpp:
   GST_OBJECT_UNLOCK (thiz);
-  if (thiz->context)
-    gst_object_replace ((GstObject **) & thiz->context, NULL);
+  gst_clear_object (&thiz->context);
   return FALSE;
 }
 

--- a/sys/msdk/gstmsdkvpp.h
+++ b/sys/msdk/gstmsdkvpp.h
@@ -89,6 +89,7 @@ struct _GstMsdkVPP
 
   /* MFX context */
   GstMsdkContext *context;
+  GstMsdkContext *old_context;
   mfxVideoParam param;
   guint in_num_surfaces;
   guint out_num_surfaces;


### PR DESCRIPTION
commit 6a847f73e22e9ae7fba0561946bfb7f46cada1d0:

```
msdk: Use gst_clear_object()
`gst_object_replace()` is not supposed to be used for unreffing and
NULLing objects.
```

commit fc200e082f2dacec29f00205f328ab1c5da68e02:

```
msdk: Fix warning about unused variable on Windows
```

commit bf36fbfc73342a77a283b60fa409a5381403802a:

```
msdk: Reorganize context preparation code
Split it out into a separate function with early exits to make the
flow clearer, and document what the function is doing clearly.
No functional changes.
```

commit 04aa692ce94fa2bc48fbcb051455d9c73579af47:

```
msdk: Fix increasing memory usage in dynamic pipelines
Our context is non-persistent, and we propagate it throughout the
pipeline. This means that if we try to reuse any gstmsdk element by
removing it from the pipeline and then re-adding it, we'll clone the
mfxSession and create a new gstmsdk context as a child of the old one
inside `gst_msdk_context_new_with_parent()`.

Normally this only allocates a few KB inside the driver, but on
Windows it seems to allocate tens of MBs which leads to linearly
increasing memory usage for each PLAYING->NULL->PLAYING state cycle
for the process. The contexts will only be freed when the pipeline
itself goes to `NULL`, which would defeat the purpose of dynamic
pipelines.

Essentially, we need to optimize the case in which the element is
removed from the pipeline and re-added and the same context is re-set
on it. To detect that case, we set the context on `old_context`, and
compare it to the new one when preparing the context. If they're the
same, we don't need to do anything.
```

Fixes https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad/issues/946
