### PR TITLE
libs: h265parser: return _NO_NAL_END if parse_nalu_header fails

### DIFF
--- a/gst-libs/gst/codecparsers/gsth265parser.c
+++ b/gst-libs/gst/codecparsers/gsth265parser.c
@@ -1431,7 +1431,7 @@ gst_h265_parser_identify_nalu_unchecked (GstH265Parser * parser,
   if (!gst_h265_parse_nalu_header (nalu)) {
     GST_WARNING ("error parsing \"NAL unit header\"");
     nalu->size = 0;
-    return GST_H265_PARSER_BROKEN_DATA;
+    return GST_H265_PARSER_NO_NAL_END;
   }
 
   nalu->valid = TRUE;


### PR DESCRIPTION
Give users (e.g. h265parse) a chance to provide more data if
NALU header parsing fails.

Fixes gstreamer#547