### PR TITLE
msdkvpp: do not hold too many input buffers in locked list

### DIFF
--- a/sys/msdk/gstmsdkvpp.c
+++ b/sys/msdk/gstmsdkvpp.c
@@ -200,9 +200,16 @@ release_msdk_surface (GstMsdkVPP * thiz, MsdkSurface * surface, GList ** list)
 }
 
 static void
-release_in_surface (GstMsdkVPP * thiz, MsdkSurface * surface)
+release_in_surface (GstMsdkVPP * thiz, MsdkSurface * surface,
+    gboolean locked_by_others)
 {
-  release_msdk_surface (thiz, surface, &thiz->locked_in_surfaces);
+  if (locked_by_others) {
+    /* mfxFrameSurface1 locked by others, others will hold the surface->buf reference */
+    /* we are good to release it here */
+    free_msdk_surface (surface);
+  } else {
+    release_msdk_surface (thiz, surface, &thiz->locked_in_surfaces);
+  }
 }
 
 static void
@@ -841,6 +848,7 @@ gst_msdkvpp_transform (GstBaseTransform * trans, GstBuffer * inbuf,
   mfxFrameInfo *in_info = NULL;
   MsdkSurface *in_surface = NULL;
   MsdkSurface *out_surface = NULL;
+  gboolean locked_by_others;
 
   timestamp = GST_BUFFER_TIMESTAMP (inbuf);
   free_unlocked_msdk_surfaces (thiz);
@@ -854,6 +862,7 @@ gst_msdkvpp_transform (GstBaseTransform * trans, GstBuffer * inbuf,
     free_msdk_surface (in_surface);
     return GST_FLOW_ERROR;
   }
+  locked_by_others = ! !in_surface->surface->Data.Locked;
 
   if (gst_msdk_is_msdk_buffer (outbuf)) {
     out_surface = g_slice_new0 (MsdkSurface);
@@ -944,7 +953,7 @@ error_push_buffer:
       gst_flow_get_name (ret));
 
 transform_end:
-  release_in_surface (thiz, in_surface);
+  release_in_surface (thiz, in_surface, locked_by_others);
   release_out_surface (thiz, out_surface);
 
   return ret;

--- a/sys/msdk/gstmsdkvpp.c
+++ b/sys/msdk/gstmsdkvpp.c
@@ -188,12 +188,11 @@ free_msdk_surface (gpointer p)
 }
 
 static void
-release_msdk_surface (GstMsdkVPP * thiz, MsdkSurface * surface)
+release_msdk_surface (GstMsdkVPP * thiz, MsdkSurface * surface, GList ** list)
 {
   if (surface->surface) {
     if (surface->surface->Data.Locked) {
-      thiz->locked_msdk_surfaces =
-          g_list_append (thiz->locked_msdk_surfaces, surface);
+      *list = g_list_append (*list, surface);
     } else {
       free_msdk_surface (surface);
     }
@@ -201,28 +200,48 @@ release_msdk_surface (GstMsdkVPP * thiz, MsdkSurface * surface)
 }
 
 static void
-free_unlocked_msdk_surfaces (GstMsdkVPP * thiz)
+release_in_surface (GstMsdkVPP * thiz, MsdkSurface * surface)
+{
+  release_msdk_surface (thiz, surface, &thiz->locked_in_surfaces);
+}
+
+static void
+release_out_surface (GstMsdkVPP * thiz, MsdkSurface * surface)
+{
+  release_msdk_surface (thiz, surface, &thiz->locked_out_surfaces);
+}
+
+static void
+free_unlocked_msdk_surfaces_from_list (GstMsdkVPP * thiz, GList ** list)
 {
   GList *l;
   MsdkSurface *surface;
 
-  for (l = thiz->locked_msdk_surfaces; l;) {
+  for (l = *list; l;) {
     GList *next = l->next;
     surface = l->data;
     if (surface->surface->Data.Locked == 0) {
       free_msdk_surface (surface);
-      thiz->locked_msdk_surfaces =
-          g_list_delete_link (thiz->locked_msdk_surfaces, l);
+      *list = g_list_delete_link (*list, l);
     }
     l = next;
   }
 }
 
 static void
+free_unlocked_msdk_surfaces (GstMsdkVPP * thiz)
+{
+  free_unlocked_msdk_surfaces_from_list (thiz, &thiz->locked_in_surfaces);
+  free_unlocked_msdk_surfaces_from_list (thiz, &thiz->locked_out_surfaces);
+}
+
+static void
 free_all_msdk_surfaces (GstMsdkVPP * thiz)
 {
-  g_list_free_full (thiz->locked_msdk_surfaces, free_msdk_surface);
-  thiz->locked_msdk_surfaces = NULL;
+  g_list_free_full (thiz->locked_in_surfaces, free_msdk_surface);
+  thiz->locked_in_surfaces = NULL;
+  g_list_free_full (thiz->locked_out_surfaces, free_msdk_surface);
+  thiz->locked_out_surfaces = NULL;
 }
 
 static void
@@ -925,8 +944,8 @@ error_push_buffer:
       gst_flow_get_name (ret));
 
 transform_end:
-  release_msdk_surface (thiz, in_surface);
-  release_msdk_surface (thiz, out_surface);
+  release_in_surface (thiz, in_surface);
+  release_out_surface (thiz, out_surface);
 
   return ret;
 }

--- a/sys/msdk/gstmsdkvpp.h
+++ b/sys/msdk/gstmsdkvpp.h
@@ -144,7 +144,8 @@ struct _GstMsdkVPP
   guint num_extra_params;
 
   mfxFrameAllocRequest request[2];
-  GList* locked_msdk_surfaces;
+  GList* locked_in_surfaces;
+  GList* locked_out_surfaces;
 };
 
 struct _GstMsdkVPPClass


### PR DESCRIPTION
If the surface is locked before vpp, upstream takes the reference.
We do not need to take a reference for msdk in vpp.