### PR TITLE
msdk: declare external dependencies

### DIFF
--- a/sys/msdk/gstmsdk.c
+++ b/sys/msdk/gstmsdk.c
@@ -82,6 +82,31 @@ GST_DEBUG_CATEGORY (gst_msdkvp9dec_debug);
 GST_DEBUG_CATEGORY (gst_msdkvp9enc_debug);
 GST_DEBUG_CATEGORY (gst_msdkav1dec_debug);
 
+static void
+plugin_add_dependencies (GstPlugin * plugin)
+{
+#ifndef _WIN32
+  const gchar *env_vars[] = { "LIBVA_DRIVER_NAME", NULL };
+  const gchar *kernel_paths[] = { "/dev/dri", NULL };
+  const gchar *kernel_names[] = { "card", "render", NULL };
+
+  /* features get updated upon changes in /dev/dri/card* */
+  gst_plugin_add_dependency (plugin, NULL, kernel_paths, kernel_names,
+      GST_PLUGIN_DEPENDENCY_FLAG_FILE_NAME_IS_PREFIX);
+
+  /* features get updated upon changes in VA environment variables */
+  gst_plugin_add_dependency (plugin, env_vars, NULL, NULL,
+      GST_PLUGIN_DEPENDENCY_FLAG_NONE);
+
+  /* features get updated upon changes in default VA drivers
+   * directory */
+  gst_plugin_add_dependency_simple (plugin, "LIBVA_DRIVERS_PATH",
+      VA_DRIVERS_PATH, "_drv_video.so",
+      GST_PLUGIN_DEPENDENCY_FLAG_FILE_NAME_IS_SUFFIX |
+      GST_PLUGIN_DEPENDENCY_FLAG_PATHS_ARE_DEFAULT_ONLY);
+#endif
+}
+
 static gboolean
 plugin_init (GstPlugin * plugin)
 {
@@ -113,8 +138,10 @@ plugin_init (GstPlugin * plugin)
   GST_DEBUG_CATEGORY_INIT (gst_msdkvp9enc_debug, "msdkvp9enc", 0, "msdkvp9enc");
   GST_DEBUG_CATEGORY_INIT (gst_msdkav1dec_debug, "msdkav1dec", 0, "msdkav1dec");
 
+  plugin_add_dependencies (plugin);
+
   if (!msdk_is_available ())
-    return FALSE;
+    return TRUE; /* return TRUE to avoid getting blacklisted */
 
   ret = gst_element_register (plugin, "msdkh264dec", GST_RANK_NONE,
       GST_TYPE_MSDKH264DEC);

--- a/sys/msdk/meson.build
+++ b/sys/msdk/meson.build
@@ -147,12 +147,18 @@ if host_machine.system() == 'windows'
   msdk_deps = declare_dependency(dependencies: [d3d11_dep, legacy_stdio_dep])
   msdk_deps_found = d3d11_dep.found() and legacy_stdio_dep.found() and cc.get_id() == 'msvc'
 else
-  libva_dep = dependency('libva-drm', required: get_option('msdk'))
+  libva_dep = dependency('libva', required: get_option('msdk'))
+  libva_drm_dep = dependency('libva-drm', required: get_option('msdk'))
   libdl_dep = cc.find_library('dl', required: get_option('msdk'))
   libgudev_dep = dependency('gudev-1.0', required: get_option('msdk'))
   libdrm_dep = dependency('libdrm', required: get_option('msdk'))
-  msdk_deps = declare_dependency(dependencies: [libva_dep, libdl_dep, libgudev_dep, libdrm_dep])
-  msdk_deps_found = libva_dep.found() and libdl_dep.found() and libgudev_dep.found() and libdrm_dep.found()
+  msdk_deps = declare_dependency(dependencies: [libva_dep, libva_drm_dep, libdl_dep, libgudev_dep, libdrm_dep])
+  msdk_deps_found = libva_dep.found() and libva_drm_dep.found() and libdl_dep.found() and libgudev_dep.found() and libdrm_dep.found()
+  driverdir = libva_dep.get_pkgconfig_variable('driverdir')
+  if driverdir == ''
+    driverdir = join_paths(get_option('prefix'), get_option('libdir'), 'dri')
+  endif
+  cdata.set_quoted('VA_DRIVERS_PATH', '@0@'.format(driverdir))
 endif
 
 if msdk_deps_found


### PR DESCRIPTION
Track kernel and VA driver dependencies so gstreamer
will re-inspect the plugin if any of them change.

Also, do not blacklist the plugin if !msdk_is_available
since it could be a transient issue caused by one or
more external dependency issues (e.g. wrong/missing
driver specified, but corrected by user later on).

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>