### PR TITLE
msdkenc: pass color properties to MediaSDK for encoding

### DIFF
--- a/sys/msdk/gstmsdkenc.c
+++ b/sys/msdk/gstmsdkenc.c
@@ -483,6 +483,7 @@ gst_msdkenc_init_encoder (GstMsdkEnc * thiz)
   guint i;
   gboolean need_vpp = TRUE;
   GstVideoFormat encoder_input_fmt;
+  mfxExtVideoSignalInfo ext_vsi;
 
   if (thiz->initialized) {
     GST_DEBUG_OBJECT (thiz, "Already initialized");
@@ -731,6 +732,25 @@ gst_msdkenc_init_encoder (GstMsdkEnc * thiz)
   if (klass->configure) {
     if (!klass->configure (thiz))
       goto failed;
+  }
+
+  /* If color properties are available from upstream, set it and pass to MediaSDK here.
+   * MJPEG is excluded from color config below as it is different from other codecs in
+   * mfxInfoMFX struct.
+   */
+  if (thiz->param.mfx.CodecId != MFX_CODEC_JPEG && (info->colorimetry.primaries
+          || info->colorimetry.transfer || info->colorimetry.matrix)) {
+    memset (&ext_vsi, 0, sizeof (ext_vsi));
+    ext_vsi.Header.BufferId = MFX_EXTBUFF_VIDEO_SIGNAL_INFO;
+    ext_vsi.Header.BufferSz = sizeof (ext_vsi);
+    ext_vsi.ColourDescriptionPresent = 1;
+    ext_vsi.ColourPrimaries =
+        gst_video_color_primaries_to_iso (info->colorimetry.primaries);
+    ext_vsi.TransferCharacteristics =
+        gst_video_transfer_function_to_iso (info->colorimetry.transfer);
+    ext_vsi.MatrixCoefficients =
+        gst_video_color_matrix_to_iso (info->colorimetry.matrix);
+    gst_msdkenc_add_extra_param (thiz, (mfxExtBuffer *) & ext_vsi);
   }
 
   if (thiz->num_extra_params) {

--- a/sys/msdk/gstmsdkenc.h
+++ b/sys/msdk/gstmsdkenc.h
@@ -37,6 +37,7 @@
 #include "msdk.h"
 #include "msdk-enums.h"
 #include "gstmsdkcontext.h"
+#include "mfxjpeg.h"
 
 G_BEGIN_DECLS
 


### PR DESCRIPTION
If upstream contains color properties info, it should be passed to MediaSDK by mfxExtVideoSignalInfo and encoded to the header.