### PR TITLE
msdkh265enc: Insert HDR SEIs

### DIFF
--- a/sys/msdk/gstmsdkenc.c
+++ b/sys/msdk/gstmsdkenc.c
@@ -736,11 +736,13 @@ gst_msdkenc_init_encoder (GstMsdkEnc * thiz)
   }
 
   /* If color properties are available from upstream, set it and pass to MediaSDK here.
-   * MJPEG is excluded from color config below as it is different from other codecs in
-   * mfxInfoMFX struct.
+   * MJPEG and VP9 are excluded as MediaSDK does not support to handle video param
+   * extbuff with buffer id equals to MFX_EXTBUFF_VIDEO_SIGNAL_INFO.
    */
-  if (thiz->param.mfx.CodecId != MFX_CODEC_JPEG && (info->colorimetry.primaries
-          || info->colorimetry.transfer || info->colorimetry.matrix)) {
+  if (thiz->param.mfx.CodecId != MFX_CODEC_JPEG &&
+      thiz->param.mfx.CodecId != MFX_CODEC_VP9 &&
+      (info->colorimetry.primaries || info->colorimetry.transfer
+          || info->colorimetry.matrix)) {
     memset (&ext_vsi, 0, sizeof (ext_vsi));
     ext_vsi.Header.BufferId = MFX_EXTBUFF_VIDEO_SIGNAL_INFO;
     ext_vsi.Header.BufferSz = sizeof (ext_vsi);

--- a/sys/msdk/gstmsdkh265enc.c
+++ b/sys/msdk/gstmsdkh265enc.c
@@ -246,14 +246,123 @@ gst_msdkh265enc_add_cc (GstMsdkH265Enc * thiz, GstVideoCodecFrame * frame)
 
   gst_msdkh265enc_insert_sei (thiz, frame, mem);
   gst_memory_unref (mem);
+  g_array_set_size (thiz->cc_sei_array, 0);
+}
+
+static void
+gst_msdkh265enc_add_mdcv_sei (GstMsdkEnc * encoder, GstVideoCodecFrame * frame)
+{
+  GstMsdkH265Enc *thiz = GST_MSDKH265ENC (encoder);
+  if (!encoder->input_state->mastering_display_info)
+    return;
+  GstVideoMasteringDisplayInfo *mastering_display_info =
+      encoder->input_state->mastering_display_info;
+
+  GstMemory *mem = NULL;
+  guint i = 0;
+
+  GstH265MasteringDisplayColourVolume *mdcv;
+  GstH265SEIMessage sei;
+
+  memset (&sei, 0, sizeof (GstH265SEIMessage));
+  sei.payloadType = GST_H265_SEI_MASTERING_DISPLAY_COLOUR_VOLUME;
+  mdcv = &sei.payload.mastering_display_colour_volume;
+
+  for (i = 0; i < 3; i++) {
+    mdcv->display_primaries_x[i] =
+        mastering_display_info->display_primaries[i].x;
+    mdcv->display_primaries_y[i] =
+        mastering_display_info->display_primaries[i].y;
+  }
+
+  mdcv->white_point_x = mastering_display_info->white_point.x;
+  mdcv->white_point_y = mastering_display_info->white_point.y;
+  mdcv->max_display_mastering_luminance =
+      mastering_display_info->max_display_mastering_luminance;
+  mdcv->min_display_mastering_luminance =
+      mastering_display_info->min_display_mastering_luminance;
+
+  if (!thiz->cc_sei_array)
+    thiz->cc_sei_array = g_array_new (FALSE, FALSE, sizeof (GstH265SEIMessage));
+
+  g_array_append_val (thiz->cc_sei_array, sei);
+
+  if (!thiz->cc_sei_array || !thiz->cc_sei_array->len)
+    return;
+
+  /* layer_id and temporal_id will be updated by parser later */
+  mem = gst_h265_create_sei_memory (0, 1, 4, thiz->cc_sei_array);
+
+  if (!mem) {
+    GST_WARNING_OBJECT (thiz, "Cannot create SEI nal unit");
+    return;
+  }
+
+  GST_DEBUG_OBJECT (thiz,
+      "Inserting %d mastering display colout volume SEI message(s)",
+      thiz->cc_sei_array->len);
+
+  gst_msdkh265enc_insert_sei (thiz, frame, mem);
+  gst_memory_unref (mem);
+  g_array_set_size (thiz->cc_sei_array, 0);
+}
+
+static void
+gst_msdkh265enc_add_cll_sei (GstMsdkEnc * encoder, GstVideoCodecFrame * frame)
+{
+  GstMsdkH265Enc *thiz = GST_MSDKH265ENC (encoder);
+  if (!encoder->input_state->content_light_level)
+    return;
+  GstVideoContentLightLevel *content_light_level =
+      encoder->input_state->content_light_level;
+
+  GstMemory *mem = NULL;
+
+  GstH265ContentLightLevel *cll;
+  GstH265SEIMessage sei;
+
+  memset (&sei, 0, sizeof (GstH265SEIMessage));
+  sei.payloadType = GST_H265_SEI_CONTENT_LIGHT_LEVEL;
+  cll = &sei.payload.content_light_level;
+
+  cll->max_content_light_level = content_light_level->max_content_light_level;
+  cll->max_pic_average_light_level =
+      content_light_level->max_frame_average_light_level;
+
+  if (!thiz->cc_sei_array)
+    thiz->cc_sei_array = g_array_new (FALSE, FALSE, sizeof (GstH265SEIMessage));
+
+  g_array_append_val (thiz->cc_sei_array, sei);
+
+  if (!thiz->cc_sei_array || !thiz->cc_sei_array->len)
+    return;
+
+  /* layer_id and temporal_id will be updated by parser later */
+  mem = gst_h265_create_sei_memory (0, 1, 4, thiz->cc_sei_array);
+
+  if (!mem) {
+    GST_WARNING_OBJECT (thiz, "Cannot create SEI nal unit");
+    return;
+  }
+
+  GST_DEBUG_OBJECT (thiz,
+      "Inserting %d content light level SEI message(s)",
+      thiz->cc_sei_array->len);
+
+  gst_msdkh265enc_insert_sei (thiz, frame, mem);
+  gst_memory_unref (mem);
+  g_array_set_size (thiz->cc_sei_array, 0);
 }
 
 static GstFlowReturn
 gst_msdkh265enc_pre_push (GstVideoEncoder * encoder, GstVideoCodecFrame * frame)
 {
   GstMsdkH265Enc *thiz = GST_MSDKH265ENC (encoder);
+  GstMsdkEnc *msdk_encoder = GST_MSDKENC (encoder);
 
   gst_msdkh265enc_add_cc (thiz, frame);
+  gst_msdkh265enc_add_mdcv_sei (msdk_encoder, frame);
+  gst_msdkh265enc_add_cll_sei (msdk_encoder, frame);
 
   return GST_FLOW_OK;
 }


### PR DESCRIPTION
There are two HDR SEIs defined in spec: mastering display colour volume and
content light level. When user wants to handle HDR coding and utilize
HDR data for display, these information should be encoded as SEI messages.